### PR TITLE
Fix re-prompting issue & improve process handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kill-my-port",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Easily kill processes running",
   "type": "module",
   "main": "index.js",


### PR DESCRIPTION
This PR improves the behavior of `kill-my-port` by ensuring that:  

- If a **port is provided via CLI (`npx kill-my-port 3000`) and not in use, it exits instead of re-asking**.  
- If **no port is provided, it lists active ports and prompts for selection**.  
- Errors and empty outputs are **handled properly with better messaging**.  
- Introduced an `exit()` function for **cleaner script termination**.  

**Changes:**  

- Updated `killProcess(port, isUserInput)` to handle CLI vs. interactive modes.  
- Fixed looping behavior in `listPorts()`.  
- Enhanced messaging for clarity.  

**Testing Done:**  

- Ran on Windows.  
- Verified proper behavior when:  
  - [x] Port is provided & running 
  - [x] Port is provided but **not running**
  - [x] No port provided
  - [x] User cancels operation
